### PR TITLE
Possibility to choose the statistics reported

### DIFF
--- a/R/light_table.R
+++ b/R/light_table.R
@@ -24,6 +24,8 @@
 #'  will apply
 #'  to the following three columns (i.e., columns
 #'  number four, five and six).
+#' @param stats.list A character vector that specifies which model statistics should
+#'  be kept in the regression table output. See `details` section
 #' @param column.labels Label for columns
 #' @param covariate.labels A character vector of labels for
 #'  columns in regression tables.
@@ -50,9 +52,22 @@
 #' This function is designed to produce `latex` tables with
 #'  stripped objects (see \link{strip}). It follows
 #'  `stargazer` standards but proposes a
-#'  simplified framework. Customization is limiteds
+#'  simplified framework. Customization is limited
 #'
-#' @return A character vector.
+#' @return A character vector. The table is printed in the viewer
+#'  if `type` is *html* and `visualize` is `TRUE`.
+#'
+#' @details The statistics that are accepted are, for the moment:
+#' \itemize{
+#'  \item{*"n"*: }{Number of observations}
+#'  \item{*"ll"*: }{Log likelihood}
+#'  \item{*"lln"*}{Log likelihood by observation}
+#'  \item{*"bic"*: }{Bayesian Information Criterion}
+#'  \item{*"link"*: }{Distribution used for count and selection models}
+#'  \item{*"alpha"*: }{Dispersion parameter for negative binomial models}
+#'  \item{*"sigma"*: }{Estimated standard deviation. See \link[stats]{sigma}}
+#' }
+#'
 #'
 #' @examples \dontrun{data("bioChemists", package = "pscl")
 #'

--- a/R/light_table.R
+++ b/R/light_table.R
@@ -89,6 +89,7 @@ light_table <- function(object,
                         covariate.labels = NULL,
                         order_variable = NULL,
                         stats.var.separate = NULL,
+                        stats.list = c("n", "lln", "bic"),
                         notes = "notes to add",
                         add.lines = "",
                         rules_between_covariates = NULL,
@@ -197,6 +198,7 @@ light_table.default <- function(
                                    type = type,
                                    ncols_models = ncols_models,
                                    stats.var.separate = stats.var.separate,
+                                   stats.list = stats.list,
                                    ...)
 
   table_total <- c(table_total, stats_table)

--- a/R/light_table.R
+++ b/R/light_table.R
@@ -113,6 +113,7 @@ light_table.default <- function(
   covariate.labels = NULL,
   order_variable = NULL,
   stats.var.separate = NULL,
+  stats.list = c("n", "lln", "bic"),
   notes = "notes to add",
   add.lines = "",
   rules_between_covariates = NULL,

--- a/R/light_table_stats.R
+++ b/R/light_table_stats.R
@@ -22,16 +22,16 @@ light_table_stats <- function(object, type = c("latex", "html"), ncols_models, s
 
 }
 
-light_table_stats_latex <- function(object, ncols_models, stats.var.separate, ...){
+light_table_stats_latex <- function(object, ncols_models, stats.var.separate, stats.list, ...){
 
   # COMPUTE STATISTICS -------------------
 
   if (ncols_models>1){
-    statsdf <- lapply(object, liststats, ...)
+    statsdf <- lapply(object, liststats, stats.list, ...)
     statsdf <- Reduce(function(dtf1, dtf2) merge(dtf1, dtf2, by = c("stat","order"), all = TRUE),
                       statsdf)
   } else{
-    statsdf <- liststats(object, ...)
+    statsdf <- liststats(object, stats.list, ...)
   }
 
   statsdf <- statsdf[order(statsdf$order),]
@@ -84,11 +84,11 @@ light_table_stats_html <- function(object, ncols_models, stats.var.separate, ...
   # COMPUTE STATISTICS -------------------
 
   if (ncols_models>1){
-    statsdf <- lapply(object, liststats, ...)
+    statsdf <- lapply(object, liststats, stats.list, ...)
     statsdf <- Reduce(function(dtf1, dtf2) merge(dtf1, dtf2, by = c("stat","order"), all = TRUE),
                       statsdf)
   } else{
-    statsdf <- liststats(object,...)
+    statsdf <- liststats(object, stats.list, ...)
   }
 
   statsdf <- statsdf[order(statsdf$order),]

--- a/R/light_table_stats.R
+++ b/R/light_table_stats.R
@@ -1,4 +1,5 @@
-light_table_stats <- function(object, type = c("latex", "html"), ncols_models, stats.var.separate, ...){
+light_table_stats <- function(object, type = c("latex", "html"), ncols_models, stats.var.separate,
+                              stats.list, ...){
 
   type <- match.arg(type)
 
@@ -7,6 +8,7 @@ light_table_stats <- function(object, type = c("latex", "html"), ncols_models, s
       light_table_stats_latex(
         object = object, ncols_models = ncols_models,
         stats.var.separate = stats.var.separate,
+        stats.list = stats.list,
         ...
       )
     )
@@ -15,6 +17,7 @@ light_table_stats <- function(object, type = c("latex", "html"), ncols_models, s
       light_table_stats_html(
         object = object, ncols_models = ncols_models,
         stats.var.separate = stats.var.separate,
+        stats.list = stats.list,
         ...
       )
     )
@@ -27,11 +30,11 @@ light_table_stats_latex <- function(object, ncols_models, stats.var.separate, st
   # COMPUTE STATISTICS -------------------
 
   if (ncols_models>1){
-    statsdf <- lapply(object, liststats, stats.list, ...)
+    statsdf <- lapply(object, liststats, stats.list = stats.list, ...)
     statsdf <- Reduce(function(dtf1, dtf2) merge(dtf1, dtf2, by = c("stat","order"), all = TRUE),
                       statsdf)
   } else{
-    statsdf <- liststats(object, stats.list, ...)
+    statsdf <- liststats(object, stats.list = stats.list, ...)
   }
 
   statsdf <- statsdf[order(statsdf$order),]
@@ -79,7 +82,8 @@ light_table_stats_latex <- function(object, ncols_models, stats.var.separate, st
 
 
 
-light_table_stats_html <- function(object, ncols_models, stats.var.separate, ...){
+light_table_stats_html <- function(object, ncols_models, stats.var.separate,
+                                   stats.list, ...){
 
   # COMPUTE STATISTICS -------------------
 

--- a/R/liststats.R
+++ b/R/liststats.R
@@ -208,6 +208,16 @@ liststats.default <- function(object, ...){
     stats.list <- args[['stats.list']]
   }
 
+  if (isTRUE('add_link' %in% names(args))){
+    stats.list <- c(stats.list, "link")
+  }
+  if (isTRUE('add_sigma' %in% names(args))){
+    stats.list <- c(stats.list, "sigma")
+  }
+  if (isTRUE('add_alpha' %in% names(args))){
+    stats.list <- c(stats.list, "alpha")
+  }
+
 
   if (as.character(object$call[1]) == "lm" && inherits(object, "light.lm"))
     return(liststats.light.lm(object, ...))
@@ -216,7 +226,7 @@ liststats.default <- function(object, ...){
   llk <- as.numeric(logLik(object))
   bic <- BIC(object)
 
-  if (isTRUE('add_link' %in% names(args)) || isTRUE('link' %in% stats.list)){
+  if (isTRUE('link' %in% stats.list)){
 
 
     if (inherits(object, "glm")){
@@ -258,11 +268,11 @@ liststats.default <- function(object, ...){
   )
 
 
-  if (isTRUE('add_link' %in% names(args)) || isTRUE('link' %in% stats.list)){
+  if (isTRUE('link' %in% stats.list)){
     stat_labels <- c(link_labels,
                      stat_labels)
     stat_val <- c(link_count, link_selection, stat_val)
-    stat_shortcode <- c(stat_shortcode, "link")
+    stat_shortcode <- c("link", "link", stat_shortcode)
   }
 
 
@@ -273,7 +283,7 @@ liststats.default <- function(object, ...){
   )
 
 
-  if (isTRUE('add_alpha' %in% names(args)) || isTRUE('alpha' %in% stats.list)){
+  if (isTRUE('alpha' %in% stats.list)){
 
     df <- rbind(data.frame(stat = "$\\alpha$ (dispersion)",
                            order = 0,
@@ -283,7 +293,7 @@ liststats.default <- function(object, ...){
 
   }
 
-  if (isTRUE('add_sigma' %in% names(args)) || isTRUE('sigma' %in% stats.list)){
+  if (isTRUE('sigma' %in% stats.list)){
     est_sigma <- mean(sigma(object))
     df <- rbind(data.frame(stat = "$\\widehat{\\sigma}$",
                            order = -1,
@@ -294,6 +304,8 @@ liststats.default <- function(object, ...){
 
   df <- cbind(df, 'shortcode' = stat_shortcode)
   df <- df[as.character(df$shortcode) %in% stats.list, ]
+
+  df$shortcode <- NULL
 
   return(df)
 }

--- a/R/liststats.R
+++ b/R/liststats.R
@@ -42,13 +42,13 @@ liststats.light.zeroinfl <- function(object, ...){
     stats.list <- args[['stats.list']]
   }
 
-  if (isTRUE('add_link' %in% names(args))){
+  if (isTRUE('add_link' %in% names(args)) && (isFALSE("link" %in% stats.list))){
     stats.list <- c(stats.list, "link")
   }
-  if (isTRUE('add_sigma' %in% names(args))){
+  if (isTRUE('add_sigma' %in% names(args))  && (isFALSE("sigma" %in% stats.list))){
     stats.list <- c(stats.list, "sigma")
   }
-  if (isTRUE('add_alpha' %in% names(args))){
+  if (isTRUE('add_alpha' %in% names(args)) && (isFALSE("alpha" %in% stats.list))){
     stats.list <- c(stats.list, "alpha")
   }
 
@@ -115,13 +115,13 @@ liststats.zeroinfl <- function(object, ...){
     stats.list <- args[['stats.list']]
   }
 
-  if (isTRUE('add_link' %in% names(args))){
+  if (isTRUE('add_link' %in% names(args)) && (isFALSE("link" %in% stats.list))){
     stats.list <- c(stats.list, "link")
   }
-  if (isTRUE('add_sigma' %in% names(args))){
+  if (isTRUE('add_sigma' %in% names(args))  && (isFALSE("sigma" %in% stats.list))){
     stats.list <- c(stats.list, "sigma")
   }
-  if (isTRUE('add_alpha' %in% names(args))){
+  if (isTRUE('add_alpha' %in% names(args)) && (isFALSE("alpha" %in% stats.list))){
     stats.list <- c(stats.list, "alpha")
   }
 
@@ -185,13 +185,13 @@ liststats.light.glm <- function(object, ...){
     stats.list <- args[['stats.list']]
   }
 
-  if (isTRUE('add_link' %in% names(args))){
+  if (isTRUE('add_link' %in% names(args)) && (isFALSE("link" %in% stats.list))){
     stats.list <- c(stats.list, "link")
   }
-  if (isTRUE('add_sigma' %in% names(args))){
+  if (isTRUE('add_sigma' %in% names(args))  && (isFALSE("sigma" %in% stats.list))){
     stats.list <- c(stats.list, "sigma")
   }
-  if (isTRUE('add_alpha' %in% names(args))){
+  if (isTRUE('add_alpha' %in% names(args)) && (isFALSE("alpha" %in% stats.list))){
     stats.list <- c(stats.list, "alpha")
   }
 
@@ -264,13 +264,13 @@ liststats.default <- function(object, ...){
     stats.list <- args[['stats.list']]
   }
 
-  if (isTRUE('add_link' %in% names(args))){
+  if (isTRUE('add_link' %in% names(args)) && (isFALSE("link" %in% stats.list))){
     stats.list <- c(stats.list, "link")
   }
-  if (isTRUE('add_sigma' %in% names(args))){
+  if (isTRUE('add_sigma' %in% names(args))  && (isFALSE("sigma" %in% stats.list))){
     stats.list <- c(stats.list, "sigma")
   }
-  if (isTRUE('add_alpha' %in% names(args))){
+  if (isTRUE('add_alpha' %in% names(args)) && (isFALSE("alpha" %in% stats.list))){
     stats.list <- c(stats.list, "alpha")
   }
 
@@ -372,6 +372,22 @@ liststats.default <- function(object, ...){
 liststats.light.lm <- function(object, ...){
 
   args <- list(...)
+
+  if (isFALSE("stats.list" %in% names(args))){
+    stats.list <- c("n","lln","bic")
+  } else{
+    stats.list <- args[['stats.list']]
+  }
+
+  if (isTRUE('add_link' %in% names(args)) && (isFALSE("link" %in% stats.list))){
+    stats.list <- c(stats.list, "link")
+  }
+  if (isTRUE('add_sigma' %in% names(args))  && (isFALSE("sigma" %in% stats.list))){
+    stats.list <- c(stats.list, "sigma")
+  }
+  if (isTRUE('add_alpha' %in% names(args)) && (isFALSE("alpha" %in% stats.list))){
+    stats.list <- c(stats.list, "alpha")
+  }
 
   # IF glm OBJECT USE DIFFERENT FUNCTION
   if (inherits(object, "light.glm")) return(liststats.light.glm(object, ...))

--- a/R/liststats.R
+++ b/R/liststats.R
@@ -87,9 +87,23 @@ liststats.zeroinfl <- function(object, ...){
 
   if (inherits(object, "light.zeroinfl")) return(liststats.light.zeroinfl(object, ...))
 
+
   args <- list(...)
+
   if (isFALSE("stats.list" %in% names(args))){
     stats.list <- c("n","lln","bic")
+  } else{
+    stats.list <- args[['stats.list']]
+  }
+
+  if (isTRUE('add_link' %in% names(args))){
+    stats.list <- c(stats.list, "link")
+  }
+  if (isTRUE('add_sigma' %in% names(args))){
+    stats.list <- c(stats.list, "sigma")
+  }
+  if (isTRUE('add_alpha' %in% names(args))){
+    stats.list <- c(stats.list, "alpha")
   }
 
 
@@ -129,6 +143,10 @@ liststats.zeroinfl <- function(object, ...){
                          val = alpha_value), df
   )
 
+  df$shortlist <- c("alpha","link","link","n","ll","lln","bic")
+
+  df <- df[df$shortlist %in% stats.list, ]
+  df$shortlist <- NULL
   return(df)
 }
 

--- a/R/liststats.R
+++ b/R/liststats.R
@@ -179,7 +179,7 @@ liststats.light.glm <- function(object, ...){
 
   args <- list(...)
 
-  if (isFALSE("list.stats" %in% names(args))){
+  if (isFALSE("stats.list" %in% names(args))){
     stats.list <- c("n","lln","bic")
   } else{
     stats.list <- args[['stats.list']]

--- a/R/liststats.R
+++ b/R/liststats.R
@@ -178,8 +178,21 @@ liststats.light.glm <- function(object, ...){
   if (!inherits(object, "light.glm")) stop("Object is not light.glm")
 
   args <- list(...)
-  if (isFALSE("stats.list" %in% names(args))){
+
+  if (isFALSE("list.stats" %in% names(args))){
     stats.list <- c("n","lln","bic")
+  } else{
+    stats.list <- args[['stats.list']]
+  }
+
+  if (isTRUE('add_link' %in% names(args))){
+    stats.list <- c(stats.list, "link")
+  }
+  if (isTRUE('add_sigma' %in% names(args))){
+    stats.list <- c(stats.list, "sigma")
+  }
+  if (isTRUE('add_alpha' %in% names(args))){
+    stats.list <- c(stats.list, "alpha")
   }
 
 
@@ -229,6 +242,11 @@ liststats.light.glm <- function(object, ...){
   df <- rbind(data.frame(stat = "$\\alpha$ (dispersion)",
                          order = 0,
                          val = alpha), df)
+
+  df$shortlist <- c("alpha","link","link","n","ll","lln","bic")
+
+  df <- df[df$shortlist %in% stats.list, ]
+  df$shortlist <- NULL
 
   return(df)
 }

--- a/R/liststats.R
+++ b/R/liststats.R
@@ -35,9 +35,23 @@ liststats.light.zeroinfl <- function(object, ...){
   if (!inherits(object, "light.zeroinfl")) stop("Object is not light.zeroinfl")
 
   args <- list(...)
+
   if (isFALSE("stats.list" %in% names(args))){
     stats.list <- c("n","lln","bic")
+  } else{
+    stats.list <- args[['stats.list']]
   }
+
+  if (isTRUE('add_link' %in% names(args))){
+    stats.list <- c(stats.list, "link")
+  }
+  if (isTRUE('add_sigma' %in% names(args))){
+    stats.list <- c(stats.list, "sigma")
+  }
+  if (isTRUE('add_alpha' %in% names(args))){
+    stats.list <- c(stats.list, "alpha")
+  }
+
 
   llk <- object$loglik
   bic <- BIC(object)
@@ -74,6 +88,11 @@ liststats.light.zeroinfl <- function(object, ...){
                          order = 0,
                          val = alpha_value), df
   )
+
+  df$shortlist <- c("alpha","link","link","n","ll","lln","bic")
+
+  df <- df[df$shortlist %in% stats.list, ]
+  df$shortlist <- NULL
 
   return(df)
 }
@@ -147,6 +166,7 @@ liststats.zeroinfl <- function(object, ...){
 
   df <- df[df$shortlist %in% stats.list, ]
   df$shortlist <- NULL
+
   return(df)
 }
 
@@ -339,10 +359,28 @@ liststats.light.lm <- function(object, ...){
   if (inherits(object, "light.glm")) return(liststats.light.glm(object, ...))
 
 
+  if (isFALSE("stats.list" %in% names(args))){
+    stats.list <- c("n","lln","bic")
+  } else{
+    stats.list <- args[['stats.list']]
+  }
+
+  if (isTRUE('add_link' %in% names(args))){
+    stats.list <- c(stats.list, "link")
+  }
+  if (isTRUE('add_sigma' %in% names(args))){
+    stats.list <- c(stats.list, "sigma")
+  }
+  if (isTRUE('add_alpha' %in% names(args))){
+    stats.list <- c(stats.list, "alpha")
+  }
+
+
+
   llk <- object$loglikelihood
   bic <- object$bic
 
-  if ('add_link' %in% names(args)){
+  if (isTRUE('link' %in% stats.list)){
 
 
 
@@ -381,11 +419,15 @@ liststats.light.lm <- function(object, ...){
     format(bic, digits = 0L, big.mark=",", scientific = FALSE)
   )
 
+  stat_shortcode <- c(
+    "n", "ll", "lln", "bic"
+  )
 
-  if ('add_link' %in% names(args)){
+  if (isTRUE('link' %in% stats.list)){
     stat_labels <- c(link_labels,
                      stat_labels)
     stat_val <- c(link_count, link_selection, stat_val)
+    stat_shortcode <- c("link", "link", stat_shortcode)
   }
 
 
@@ -396,21 +438,27 @@ liststats.light.lm <- function(object, ...){
   )
 
 
-  if ('add_alpha' %in% names(args)){
+  if (isTRUE('alpha' %in% stats.list)){
     df <- rbind(data.frame(stat = "$\\alpha$ (dispersion)",
                            order = 0,
                            val = extract_alpha(object)), df
     )
+    stat_shortcode <- c("alpha", stat_shortcode)
   }
 
-  if ('add_sigma' %in% names(args)){
+  if ('sigma' %in% stats.list){
     est_sigma <- mean(sigma(object))
     df <- rbind(data.frame(stat = "$\\widehat{\\sigma}$",
                            order = -1,
                            val = est_sigma), df
     )
+    stat_shortcode <- c("sigma", stat_shortcode)
   }
 
+  df <- cbind(df, 'shortcode' = stat_shortcode)
+  df <- df[as.character(df$shortcode) %in% stats.list, ]
+
+  df$shortcode <- NULL
 
   return(df)
 }

--- a/man/light_table.Rd
+++ b/man/light_table.Rd
@@ -71,6 +71,9 @@ will apply
 to the following three columns (i.e., columns
 number four, five and six).}
 
+\item{stats.list}{A character vector that specifies which model statistics should
+be kept in the regression table output. See \code{details} section}
+
 \item{notes}{Notes that should be added at the end}
 
 \item{add.lines}{Rows to add in object statistics part}
@@ -93,16 +96,29 @@ the table on Rstudio viewer. Ignored if \code{type} = \emph{latex}
 This function is designed to produce \code{latex} tables with
 stripped objects (see \link{strip}). It follows
 \code{stargazer} standards but proposes a
-simplified framework. Customization is limiteds}
+simplified framework. Customization is limited}
 
 \item{...}{Additional arguments that should be passed. See, for instance,
 \link{liststats}}
 }
 \value{
-A character vector.
+A character vector. The table is printed in the viewer
+if \code{type} is \emph{html} and \code{visualize} is \code{TRUE}.
 }
 \description{
 Produce latex tables from stripped objects to reduce memory needs
+}
+\details{
+The statistics that are accepted are, for the moment:
+\itemize{
+\item{\emph{"n"}: }{Number of observations}
+\item{\emph{"ll"}: }{Log likelihood}
+\item{\emph{"lln"}}{Log likelihood by observation}
+\item{\emph{"bic"}: }{Bayesian Information Criterion}
+\item{\emph{"link"}: }{Distribution used for count and selection models}
+\item{\emph{"alpha"}: }{Dispersion parameter for negative binomial models}
+\item{\emph{"sigma"}: }{Estimated standard deviation. See \link[stats]{sigma}}
+}
 }
 \examples{
 \dontrun{data("bioChemists", package = "pscl")

--- a/man/light_table.Rd
+++ b/man/light_table.Rd
@@ -16,6 +16,7 @@ light_table(
   covariate.labels = NULL,
   order_variable = NULL,
   stats.var.separate = NULL,
+  stats.list = c("n", "lln", "bic"),
   notes = "notes to add",
   add.lines = "",
   rules_between_covariates = NULL,

--- a/tests/testthat/test-light_table_ols.R
+++ b/tests/testthat/test-light_table_ols.R
@@ -12,13 +12,15 @@ latex_table <- tablelight::light_table(ols,
                                        title = "My table title",
                                        label = "My table label",
                                        dep.var.labels = "My depvar",
-                                       column.labels = "My label column")
+                                       column.labels = "My label column",
+                                       stats.list = c("n","ll","lln","bic"))
 
 html_table <- tablelight::light_table(ols,
                                       type = "html",
                                       title = "My table title",
                                       dep.var.labels = "My depvar",
-                                      column.labels = "My label column")
+                                      column.labels = "My label column",
+                                      stats.list = c("n","ll","lln","bic"))
 
 
 # HEADER =========================
@@ -219,14 +221,16 @@ latex_table <- tablelight::light_table(list(ols, ols, ols),
                                        label = "My table label",
                                        dep.var.labels = c("My depvar1", "My depvar2"),
                                        dep.var.separate = c(2,1),
-                                       column.labels = c("Label1","Label2"))
+                                       column.labels = c("Label1","Label2"),
+                                       stats.list = c("n","ll","lln","bic"))
 
 html_table <- tablelight::light_table(list(ols, ols, ols),
                                       type = "html",
                                       title = "My table title",
                                       dep.var.labels = c("My depvar1", "My depvar2","toomanyvar"),
                                       dep.var.separate = c(2,1),
-                                      column.labels = c("Label1","Label2"))
+                                      column.labels = c("Label1","Label2"),
+                                      stats.list = c("n","ll","lln","bic"))
 
 
 # HEADER
@@ -424,7 +428,8 @@ fm_zip <- tablelight::strip(pscl::zeroinfl(art ~ . | ., data = bioChemists,
 
 latex_table <- light_table(list(fm_zip, fm_zip), modeltype = c("selection","outcome"),
                            dep.var.labels = c("Selection","Outcome"),
-                           stats.var.separate = 2L)
+                           stats.var.separate = 2L,
+                           stats.list = c("n","ll","lln","bic","alpha","link"))
 
 
 testthat::test_that("Summary statistics on two columns",{
@@ -515,8 +520,7 @@ fm_zinb <- tablelight::strip(pscl::zeroinfl(art ~ . | ., data = bioChemists,
 latex_table <- tablelight::light_table(list(fm_zip, fm_zip,
                                             fm_zinb, fm_zinb),
                                        modeltype = c("selection","outcome","selection","outcome"),
-                                       #                           dep.var.labels = c("ZIP","ZINB"),
-                                       #                           dep.var.separate = 2L,
+                                       stats.list = c("n","ll","lln","bic","alpha","link"),
                                        stats.var.separate = c(2L, 2L)
 )
 

--- a/tests/testthat/test-liststat.R
+++ b/tests/testthat/test-liststat.R
@@ -838,10 +838,10 @@ glm <- glm(
 light_glm <- tablelight::strip(glm)
 
 stats_glm <- tablelight::liststats(glm, add_link = TRUE, add_alpha = TRUE,
-                                   list.stats = c("n","ll","lln","bic"))
+                                   stats.list = c("n","ll","lln","bic"))
 stats_glm_strip <- tablelight::liststats(light_glm, add_link = TRUE,
                                          add_alpha = TRUE,
-                                         list.stats = c("n","ll","lln","bic"))
+                                         stats.list = c("n","ll","lln","bic"))
 
 
 ## 6.A. CHECK STATISTICS RETURNED ======
@@ -863,6 +863,16 @@ testthat::test_that(
     ),
     c(glm$family$family, '')
   )
+)
+
+testthat::test_that(
+  "add_link = TRUE equivalent to stats.list = 'link'",
+  testthat::expect_identical(
+      stats_glm_strip[grepl(x = as.character(stats_glm_strip$stat),
+                                         pattern = "(Count|Selection)"), ]
+    ,
+    tablelight::liststats(light_glm, stats.list = c("link"))
+    )
 )
 
 
@@ -934,9 +944,10 @@ glmnb_light <- tablelight::strip(glmnb)
 
 # 7.A. CHECK STATISTICS RETURNED ======
 
-stats_glmnb <- tablelight::liststats(glmnb)
-stats_glmnb_bis <- tablelight::liststats(glmnb, add_link = TRUE,
-                                         add_alpha = TRUE)
+stats_glmnb <- tablelight::liststats(glmnb_light, stats.list = c("n","ll","lln","bic"))
+stats_glmnb_bis <- tablelight::liststats(glmnb_light, add_link = TRUE,
+                                         add_alpha = TRUE,
+                                         stats.list = c("n","ll","lln","bic"))
 
 
 
@@ -956,6 +967,17 @@ testthat::test_that(
     c("Negative Binomial", '')
   )
 )
+
+testthat::test_that(
+  "If you add argument add_link = TRUE, count distribution added but no selection distribution",
+  testthat::expect_identical(
+    stats_glmnb_bis[grepl(x = as.character(stats_glmnb_bis$stat),
+                                       pattern = "(Count|Selection)"), ],
+    tablelight::liststats(glmnb_light, stats.list = c("link"))
+    )
+)
+
+
 
 
 testthat::test_that(
@@ -1206,7 +1228,8 @@ data("bioChemists", package = "pscl")
 
 zeroinfl_negbin <- gravity::fastzeroinfl(art ~ . | ., data = bioChemists, dist = "negbin")
 stats_bis_zeroinfl_negbin <- tablelight::liststats(zeroinfl_negbin,
-                                                   add_link =TRUE, add_alpha = TRUE)
+                                                   add_link =TRUE, add_alpha = TRUE,
+                                                   stats.list = c("n","ll","lln","bic"))
 
 
 
@@ -1247,6 +1270,30 @@ testthat::test_that(
     )
   }
 )
+
+
+
+testthat::test_that(
+  "add_link = TRUE or list.stats = 'link' are equivalent",
+  testthat::expect_identical(
+    stats_bis_zeroinfl_negbin[grepl(x = as.character(stats_bis_zeroinfl_negbin$stat),
+                                                 pattern = "(Count|Selection)"), ],
+    tablelight::liststats(zeroinfl_negbin,
+                          stats.list = c("link"))
+    )
+)
+
+testthat::test_that(
+  "add_alpha = TRUE or list.stats = 'alpha' are equivalent",
+  testthat::expect_identical(
+    stats_bis_zeroinfl_negbin[grepl(x = as.character(stats_bis_zeroinfl_negbin$stat),
+                                    pattern = "alpha"), ],
+    tablelight::liststats(zeroinfl_negbin,
+                          stats.list = c("alpha"))
+  )
+)
+
+
 
 
 # B/ CHECK STATISTICS VALUES ++++++
@@ -1311,9 +1358,9 @@ testthat::test_that(
 zeroinfl_poisson <- pscl::zeroinfl(art ~ . | ., data = bioChemists)
 
 
-stats_zeroinfl_poisson <- tablelight::liststats(zeroinfl_poisson)
+stats_zeroinfl_poisson <- tablelight::liststats(zeroinfl_poisson, stats.list = c("n","ll","lln","bic"))
 stats_bis_zeroinfl_poisson <- tablelight::liststats(zeroinfl_poisson, add_link = TRUE,
-                                                    add_alpha = TRUE)
+                                                    add_alpha = TRUE, stats.list = c("n","ll","lln","bic"))
 
 
 

--- a/tests/testthat/test-liststat.R
+++ b/tests/testthat/test-liststat.R
@@ -271,8 +271,8 @@ glmnb <- MASS::glm.nb(Days ~ Sex/(Age + Eth*Lrn), data = quine)
 
 # 3.A. CHECK STATISTICS RETURNED ======
 
-stats_glmnb <- tablelight::liststats(glmnb)
-stats_glmnb_bis <- tablelight::liststats(glmnb, add_link = TRUE,
+stats_glmnb <- tablelight::liststats(glmnb, stats.list = c("n","ll","lln","bic"))
+stats_glmnb_bis <- tablelight::liststats(glmnb, add_link = TRUE, stats.list = c("n","ll","lln","bic"),
                                          add_alpha = TRUE)
 
 
@@ -296,6 +296,26 @@ testthat::test_that(
 
 
 testthat::test_that(
+  "add_link = TRUE or stat = 'link' equivalent",
+  testthat::expect_equal(
+    as.character(stats_glmnb_bis[grepl(x = as.character(stats_glmnb_bis$stat),
+                                       pattern = "(Count|Selection)"),'val']),
+    as.character(tablelight::liststats(glmnb, stats.list = c("link"))[,'val'])
+  )
+)
+
+testthat::test_that(
+  "add_link = FALSE or stat = 'link' still produces link stat",
+  testthat::expect_equal(
+    as.character(stats_glmnb_bis[grepl(x = as.character(stats_glmnb_bis$stat),
+                                       pattern = "(Count|Selection)"),'val']),
+    as.character(tablelight::liststats(glmnb, add_link = FALSE, stats.list = c("link"))[,'val'])
+  )
+)
+
+
+
+testthat::test_that(
   "If you add argument add_alpha = TRUE, dispersion parameter is returned",{
     testthat::expect_equal(
       length(as.character(stats_glmnb_bis[grepl(x = as.character(stats_glmnb_bis$stat),
@@ -314,6 +334,32 @@ testthat::test_that(
     )
   }
 )
+
+
+testthat::test_that(
+  "add_alpha = TRUE equivalent to stats.list = 'alpha' ",{
+    testthat::expect_equal(
+      as.character(
+        stats_glmnb_bis[grepl(x = as.character(stats_glmnb_bis$stat),
+                              pattern = "alpha"),'val']
+      ),
+      as.character(
+        tablelight::liststats(glmnb, stats.list = c("alpha"))[,'val']
+      )
+    )
+  }
+)
+
+testthat::test_that(
+  "add_alpha = FALSE ignored if stats.list = 'alpha' ",{
+    testthat::expect_equal(
+      tablelight::liststats(glmnb, add_alpha = FALSE, stats.list = c("alpha")),
+      tablelight::liststats(glmnb, add_alpha = TRUE, stats.list = c("alpha"))
+    )
+  }
+)
+
+
 
 ## 3.B. CHECK STATISTICS VALUES ======
 
@@ -406,6 +452,7 @@ zeroinfl_negbin_strip <- tablelight::strip(zeroinfl_negbin)
 
 
 stats_bis_zeroinfl_negbin <- tablelight::liststats(zeroinfl_negbin,
+                                                   stats.list = c("n","ll","lln","bic"),
                                                    add_link = TRUE,
                                                    add_alpha = TRUE)
 
@@ -425,6 +472,29 @@ testthat::test_that(
     as.character(stats_bis_zeroinfl_negbin[grepl(x = as.character(stats_bis_zeroinfl_negbin$stat),
                                                  pattern = "(Count|Selection)"),'val']),
     c("Negative Binomial", 'Logit')
+  )
+)
+
+testthat::test_that(
+  "add_link = TRUE equivalent to stat = 'link'",
+  testthat::expect_equal(
+    as.character(stats_bis_zeroinfl_negbin[grepl(x = as.character(stats_bis_zeroinfl_negbin$stat),
+                                                 pattern = "(Count|Selection)"),'val']),
+    as.character(tablelight::liststats(zeroinfl_negbin,
+                          stats.list = c("link"),
+                          add_link = TRUE)[,'val'])
+    )
+)
+
+testthat::test_that(
+  "add_link = TRUE equivalent to stat = 'link'",
+  testthat::expect_identical(
+    tablelight::liststats(zeroinfl_negbin,
+                          stats.list = c("link"),
+                          add_link = TRUE),
+    tablelight::liststats(zeroinfl_negbin,
+                          stats.list = c("link"),
+                          add_link = FALSE)
   )
 )
 
@@ -534,6 +604,7 @@ zeroinfl_poisson <- pscl::zeroinfl(art ~ . | ., data = bioChemists)
 
 stats_zeroinfl_poisson <- tablelight::liststats(zeroinfl_poisson)
 stats_bis_zeroinfl_poisson <- tablelight::liststats(zeroinfl_poisson, add_link = TRUE,
+                                                    stats.list = c("n","ll","lln","bic"),
                                                     add_alpha = TRUE)
 
 

--- a/tests/testthat/test-liststat.R
+++ b/tests/testthat/test-liststat.R
@@ -837,8 +837,11 @@ glm <- glm(
 
 light_glm <- tablelight::strip(glm)
 
-stats_glm <- tablelight::liststats(glm, add_link = TRUE, add_alpha = TRUE)
-stats_glm_strip <- tablelight::liststats(light_glm, add_link = TRUE)
+stats_glm <- tablelight::liststats(glm, add_link = TRUE, add_alpha = TRUE,
+                                   list.stats = c("n","ll","lln","bic"))
+stats_glm_strip <- tablelight::liststats(light_glm, add_link = TRUE,
+                                         add_alpha = TRUE,
+                                         list.stats = c("n","ll","lln","bic"))
 
 
 ## 6.A. CHECK STATISTICS RETURNED ======

--- a/tests/testthat/test-liststat.R
+++ b/tests/testthat/test-liststat.R
@@ -1100,9 +1100,9 @@ glmnb <- gravity::fastglm.nb(Days ~ Sex/(Age + Eth*Lrn), data = quine)
 
 # 8.A. CHECK STATISTICS RETURNED ======
 
-stats_glmnb <- tablelight::liststats(glmnb)
+stats_glmnb <- tablelight::liststats(glmnb, stats.list = c("n","ll","lln","bic"))
 stats_glmnb_bis <- tablelight::liststats(glmnb_light, add_link = TRUE,
-                                         add_alpha = TRUE)
+                                         add_alpha = TRUE, stats.list = c("n","ll","lln","bic"))
 
 
 testthat::test_that(

--- a/tests/testthat/test-liststat.R
+++ b/tests/testthat/test-liststat.R
@@ -39,6 +39,16 @@ testthat::test_that(
 )
 
 testthat::test_that(
+  "add_link = TRUE equivalent to link in stats.list",
+  testthat::expect_identical(
+    stats_ols_bis,
+    tablelight::liststats(ols, stats.list = c("n","lln","bic","link"))
+  )
+)
+
+
+
+testthat::test_that(
   "add_link = TRUE does not modify other rows",
   testthat::expect_equal(
     stats_ols_bis[!(stats_ols_bis$stat %in% c("Count distribution","Selection distribution")),
@@ -70,15 +80,16 @@ testthat::test_that(
 
 
 testthat::test_that(
-  "'Log likelihood' field is OK",{
+  "'Log likelihood' field is OK (when asked)",{
 
+    # Not by default
     testthat::expect_equal(
-      as.character(stats_ols_bis[stats_ols_bis$stat == "Log likelihood","val"]),
-      format(as.numeric(stats::logLik(ols)), digits = 0L, big.mark = ",")
+      sum(stats_ols_bis$stat == "Log likelihood"), 0L
     )
 
+
     testthat::expect_equal(
-      as.character(stats_ols[stats_ols$stat == "Log likelihood","val"]),
+      as.character(tablelight::liststats(ols, stats.list = "ll")[,"val"]),
       format(as.numeric(stats::logLik(ols)), digits = 0L, big.mark = ",")
     )
 
@@ -159,6 +170,17 @@ testthat::test_that(
   )
 )
 
+testthat::test_that(
+  "add_link = TRUE equivalent to 'link' in stats.list",
+  testthat::expect_equal(
+    as.character(
+      stats_glm_bis[grepl(x = as.character(stats_glm_bis$stat),
+                          pattern = "(Count|Selection)"),'val']
+  ),
+  as.character(tablelight::liststats(glm, stats.list = "link")[,'val'])
+)
+)
+
 
 ## 2.B. CHECK STATISTICS VALUES ======
 
@@ -181,17 +203,19 @@ testthat::test_that(
 
 
 testthat::test_that(
-  "'Log likelihood' field is OK",{
+  "'Log likelihood' field is OK (when asked)",{
+
+    # Not by default
+    testthat::expect_equal(
+      sum(stats_glm_bis$stat == "Log likelihood"), 0L
+    )
+
 
     testthat::expect_equal(
-      as.character(stats_glm_bis[stats_glm_bis$stat == "Log likelihood","val"]),
+      as.character(tablelight::liststats(glm, stats.list = "ll")[,"val"]),
       format(as.numeric(stats::logLik(glm)), digits = 0L, big.mark = ",")
     )
 
-    testthat::expect_equal(
-      as.character(stats_glm[stats_glm$stat == "Log likelihood","val"]),
-      format(as.numeric(stats::logLik(glm)), digits = 0L, big.mark = ",")
-    )
 
   }
 
@@ -249,7 +273,7 @@ glmnb <- MASS::glm.nb(Days ~ Sex/(Age + Eth*Lrn), data = quine)
 
 stats_glmnb <- tablelight::liststats(glmnb)
 stats_glmnb_bis <- tablelight::liststats(glmnb, add_link = TRUE,
-                                       add_alpha = TRUE)
+                                         add_alpha = TRUE)
 
 
 
@@ -382,8 +406,8 @@ zeroinfl_negbin_strip <- tablelight::strip(zeroinfl_negbin)
 
 
 stats_bis_zeroinfl_negbin <- tablelight::liststats(zeroinfl_negbin,
-                                                 add_link = TRUE,
-                                                 add_alpha = TRUE)
+                                                   add_link = TRUE,
+                                                   add_alpha = TRUE)
 
 
 
@@ -510,7 +534,7 @@ zeroinfl_poisson <- pscl::zeroinfl(art ~ . | ., data = bioChemists)
 
 stats_zeroinfl_poisson <- tablelight::liststats(zeroinfl_poisson)
 stats_bis_zeroinfl_poisson <- tablelight::liststats(zeroinfl_poisson, add_link = TRUE,
-                                                  add_alpha = TRUE)
+                                                    add_alpha = TRUE)
 
 
 
@@ -832,7 +856,7 @@ glmnb_light <- tablelight::strip(glmnb)
 
 stats_glmnb <- tablelight::liststats(glmnb)
 stats_glmnb_bis <- tablelight::liststats(glmnb, add_link = TRUE,
-                                       add_alpha = TRUE)
+                                         add_alpha = TRUE)
 
 
 
@@ -976,7 +1000,7 @@ glmnb <- gravity::fastglm.nb(Days ~ Sex/(Age + Eth*Lrn), data = quine)
 
 stats_glmnb <- tablelight::liststats(glmnb)
 stats_glmnb_bis <- tablelight::liststats(glmnb_light, add_link = TRUE,
-                                       add_alpha = TRUE)
+                                         add_alpha = TRUE)
 
 
 testthat::test_that(
@@ -1102,7 +1126,7 @@ data("bioChemists", package = "pscl")
 
 zeroinfl_negbin <- gravity::fastzeroinfl(art ~ . | ., data = bioChemists, dist = "negbin")
 stats_bis_zeroinfl_negbin <- tablelight::liststats(zeroinfl_negbin,
-                                                 add_link =TRUE, add_alpha = TRUE)
+                                                   add_link =TRUE, add_alpha = TRUE)
 
 
 
@@ -1209,7 +1233,7 @@ zeroinfl_poisson <- pscl::zeroinfl(art ~ . | ., data = bioChemists)
 
 stats_zeroinfl_poisson <- tablelight::liststats(zeroinfl_poisson)
 stats_bis_zeroinfl_poisson <- tablelight::liststats(zeroinfl_poisson, add_link = TRUE,
-                                                  add_alpha = TRUE)
+                                                    add_alpha = TRUE)
 
 
 
@@ -1322,9 +1346,9 @@ zeroinfl_negbin_strip <- tablelight::strip(zeroinfl_negbin)
 
 
 stats_bis_zeroinfl_negbin <- tablelight::liststats(zeroinfl_negbin, add_link = TRUE,
-                                                 add_alpha = TRUE)
+                                                   add_alpha = TRUE)
 stats_bis_zeroinfl_negbin_strip <- tablelight::liststats(zeroinfl_negbin_strip, add_link = TRUE,
-                                                       add_alpha = TRUE)
+                                                         add_alpha = TRUE)
 
 
 
@@ -1433,9 +1457,9 @@ zeroinfl_poisson_strip <- tablelight::strip(zeroinfl_poisson)
 
 
 stats_bis_zeroinfl_poisson <- tablelight::liststats(zeroinfl_poisson, add_link = TRUE,
-                                                  add_alpha = TRUE)
+                                                    add_alpha = TRUE)
 stats_bis_zeroinfl_poisson_strip <- tablelight::liststats(zeroinfl_poisson_strip, add_link = TRUE,
-                                                        add_alpha = TRUE)
+                                                          add_alpha = TRUE)
 
 
 
@@ -1562,7 +1586,7 @@ dataset<-data.frame(y,x1,x2)
 
 
 oglm <- oglmx::oglmx(y ~ x1 + x2 + z, data=dataset,link="probit",constantMEAN=FALSE,
-                              constantSD=FALSE,delta=0,threshparam=NULL)
+                     constantSD=FALSE,delta=0,threshparam=NULL)
 
 stats_oglm <- tablelight::liststats(oglm)
 stats_oglm_bis <- tablelight::liststats(oglm, add_link = TRUE)
@@ -1583,7 +1607,7 @@ testthat::test_that(
   testthat::expect_equal(
     tolower(
       as.character(stats_oglm_bis[grepl(x = as.character(stats_oglm_bis$stat),
-                                       pattern = "(Count|Selection)"),'val'])
+                                        pattern = "(Count|Selection)"),'val'])
     ),
     c('', '')
   )

--- a/tests/testthat/test-liststat.R
+++ b/tests/testthat/test-liststat.R
@@ -714,8 +714,9 @@ ols <- lm(
 
 light_ols <- tablelight::strip(ols)
 
-stats_ols <- tablelight:::liststats(ols, add_link = TRUE)
-stats_ols_strip <- tablelight:::liststats(light_ols, add_link = TRUE)
+stats_ols <- tablelight:::liststats(ols, add_link = TRUE, stats.list = c("n","ll","lln","bic"))
+stats_ols_strip <- tablelight:::liststats(light_ols, add_link = TRUE,
+                                          stats.list = c("n","ll","lln","bic"))
 
 
 ## 5.A. CHECK STATISTICS RETURNED ======
@@ -744,6 +745,16 @@ testthat::test_that(
     'Selection distribution'
   )
 )
+
+testthat::test_that(
+  "add_link = TRUE equivalent to stat.list 'link'",
+  testthat::expect_equal(
+    stats_ols_strip[grepl("(Count|Selection)", stats_ols_strip$stat),],
+    liststats(light_ols, add_link = TRUE,
+              stats.list = c("link"))
+      )
+)
+
 
 testthat::test_that(
   "add_link = TRUE does not modify other rows",
@@ -810,11 +821,6 @@ testthat::test_that(
   }
 
 )
-
-
-
-
-
 
 
 

--- a/tests/testthat/test-liststat.R
+++ b/tests/testthat/test-liststat.R
@@ -176,9 +176,9 @@ testthat::test_that(
     as.character(
       stats_glm_bis[grepl(x = as.character(stats_glm_bis$stat),
                           pattern = "(Count|Selection)"),'val']
-  ),
-  as.character(tablelight::liststats(glm, stats.list = "link")[,'val'])
-)
+    ),
+    as.character(tablelight::liststats(glm, stats.list = "link")[,'val'])
+  )
 )
 
 
@@ -481,9 +481,9 @@ testthat::test_that(
     as.character(stats_bis_zeroinfl_negbin[grepl(x = as.character(stats_bis_zeroinfl_negbin$stat),
                                                  pattern = "(Count|Selection)"),'val']),
     as.character(tablelight::liststats(zeroinfl_negbin,
-                          stats.list = c("link"),
-                          add_link = TRUE)[,'val'])
-    )
+                                       stats.list = c("link"),
+                                       add_link = TRUE)[,'val'])
+  )
 )
 
 testthat::test_that(
@@ -752,7 +752,7 @@ testthat::test_that(
     stats_ols_strip[grepl("(Count|Selection)", stats_ols_strip$stat),],
     liststats(light_ols, add_link = TRUE,
               stats.list = c("link"))
-      )
+  )
 )
 
 
@@ -868,11 +868,11 @@ testthat::test_that(
 testthat::test_that(
   "add_link = TRUE equivalent to stats.list = 'link'",
   testthat::expect_identical(
-      stats_glm_strip[grepl(x = as.character(stats_glm_strip$stat),
-                                         pattern = "(Count|Selection)"), ]
+    stats_glm_strip[grepl(x = as.character(stats_glm_strip$stat),
+                          pattern = "(Count|Selection)"), ]
     ,
     tablelight::liststats(light_glm, stats.list = c("link"))
-    )
+  )
 )
 
 
@@ -972,9 +972,9 @@ testthat::test_that(
   "If you add argument add_link = TRUE, count distribution added but no selection distribution",
   testthat::expect_identical(
     stats_glmnb_bis[grepl(x = as.character(stats_glmnb_bis$stat),
-                                       pattern = "(Count|Selection)"), ],
+                          pattern = "(Count|Selection)"), ],
     tablelight::liststats(glmnb_light, stats.list = c("link"))
-    )
+  )
 )
 
 
@@ -1277,10 +1277,10 @@ testthat::test_that(
   "add_link = TRUE or list.stats = 'link' are equivalent",
   testthat::expect_identical(
     stats_bis_zeroinfl_negbin[grepl(x = as.character(stats_bis_zeroinfl_negbin$stat),
-                                                 pattern = "(Count|Selection)"), ],
+                                    pattern = "(Count|Selection)"), ],
     tablelight::liststats(zeroinfl_negbin,
                           stats.list = c("link"))
-    )
+  )
 )
 
 testthat::test_that(
@@ -1473,9 +1473,9 @@ zeroinfl_negbin_strip <- tablelight::strip(zeroinfl_negbin)
 
 
 stats_bis_zeroinfl_negbin <- tablelight::liststats(zeroinfl_negbin, add_link = TRUE,
-                                                   add_alpha = TRUE)
+                                                   add_alpha = TRUE, stats.list = c("n","ll","lln","bic"))
 stats_bis_zeroinfl_negbin_strip <- tablelight::liststats(zeroinfl_negbin_strip, add_link = TRUE,
-                                                         add_alpha = TRUE)
+                                                         add_alpha = TRUE, stats.list = c("n","ll","lln","bic"))
 
 
 
@@ -1516,6 +1516,25 @@ testthat::test_that(
     )
   }
 )
+
+testthat::test_that(
+  "add_link = TRUE equivalent to stats.list = 'link'",
+  testthat::expect_identical(
+    stats_bis_zeroinfl_negbin_strip[grepl(x = as.character(stats_bis_zeroinfl_negbin$stat),
+                                          pattern = "(Count|Selection)"),],
+    tablelight::liststats(zeroinfl_negbin_strip, stats.list = c("link"))
+  )
+)
+
+testthat::test_that(
+  "add_alpha = TRUE equivalent to stats.list = 'alpha'",
+  testthat::expect_identical(
+    stats_bis_zeroinfl_negbin_strip[grepl(x = as.character(stats_bis_zeroinfl_negbin$stat),
+                                          pattern = "alpha"),],
+    tablelight::liststats(zeroinfl_negbin_strip, stats.list = c("alpha"))
+  )
+)
+
 
 
 # B/ CHECK STATISTICS VALUES ++++++
@@ -1584,9 +1603,11 @@ zeroinfl_poisson_strip <- tablelight::strip(zeroinfl_poisson)
 
 
 stats_bis_zeroinfl_poisson <- tablelight::liststats(zeroinfl_poisson, add_link = TRUE,
-                                                    add_alpha = TRUE)
+                                                    add_alpha = TRUE,
+                                                    stats.list = c("n","ll","lln","bic"))
 stats_bis_zeroinfl_poisson_strip <- tablelight::liststats(zeroinfl_poisson_strip, add_link = TRUE,
-                                                          add_alpha = TRUE)
+                                                          add_alpha = TRUE,
+                                                          stats.list = c("n","ll","lln","bic"))
 
 
 
@@ -1715,8 +1736,8 @@ dataset<-data.frame(y,x1,x2)
 oglm <- oglmx::oglmx(y ~ x1 + x2 + z, data=dataset,link="probit",constantMEAN=FALSE,
                      constantSD=FALSE,delta=0,threshparam=NULL)
 
-stats_oglm <- tablelight::liststats(oglm)
-stats_oglm_bis <- tablelight::liststats(oglm, add_link = TRUE)
+stats_oglm <- tablelight::liststats(oglm, stats.list = c("n","ll","lln","bic"))
+stats_oglm_bis <- tablelight::liststats(oglm, add_link = TRUE, stats.list = c("n","ll","lln","bic"))
 
 
 # 2.A. CHECK STATISTICS RETURNED ======
@@ -1737,6 +1758,16 @@ testthat::test_that(
                                         pattern = "(Count|Selection)"),'val'])
     ),
     c('', '')
+  )
+)
+
+testthat::test_that(
+  "add_link = TRUE equivalent to stats.list = 'link'",
+  testthat::expect_identical(
+    stats_oglm_bis[grepl(x = as.character(stats_oglm_bis$stat),
+                         pattern = "(Count|Selection)"),]
+    ,
+    tablelight::liststats(oglm, stats.list = c("link"))
   )
 )
 
@@ -1817,4 +1848,24 @@ testthat::test_that(
 )
 
 
+# sigma reported for oglmx objects =====
+
+oglm <- oglmx::oglmx(y ~ x1 + x2 + z, data=dataset,link="probit",constantMEAN=FALSE,
+                     constantSD=FALSE,delta=0,threshparam=NULL)
+
+# Homosckeastic model with variance one
+testthat::test_that("Reported sigmas are ok for oglmx", {
+
+  testthat::expect_equal(
+    as.character(tablelight::liststats(oglm, stats.list = c("sigma"))[,c("stat")]),
+    "$\\widehat{\\sigma}$"
+  )
+
+  testthat::expect_equal(
+    as.character(tablelight::liststats(oglm, stats.list = c("sigma"))[,c("val")]),
+    "1"
+  )
+
+
+})
 


### PR DESCRIPTION
This `PR` proposes a modification of two internal functions to make possible for the user to choose which statistics he would like to report:

* `liststats` 
* `light_table_stats`

For the user of the :package: , it is now possible to use a `stats.list` argument in `light_table` function. Currently accepted options are:

| Code | Statistics |
|--------|--------------------------------|
| *"n"* | Number of observations |
|*"ll"* | Log likelihood |
| *"lln"* | Log likelihood by observation |
|*"bic"*|Bayesian Information Criterion|
|"link"*| Distribution used for count and selection models|
|*"alpha"* | Dispersion parameter for negative binomial models |
|*"sigma"* | Estimated standard deviation.|
 
Others should follow (object of another PR).

All tests are :heavy_check_mark: 

Close #4 
