### PR TITLE
Fix bug with multicolumn HTML tables

### DIFF
--- a/R/light_table_coefficients.R
+++ b/R/light_table_coefficients.R
@@ -118,7 +118,8 @@ light_table_coefficients <- function(object,
   body_table <- add_rules(
     body_table = body_table,
     rules_between_covariates = rules_between_covariates,
-    type = type
+    type = type,
+    ncols_models = ncols_models
   )
 
   return(body_table)

--- a/R/light_table_coefficients_inner.R
+++ b/R/light_table_coefficients_inner.R
@@ -78,7 +78,7 @@ label_variables <- function(body_table,
 
 
 add_rules <- function(body_table, rules_between_covariates,
-                      type){
+                      type, ncols_models){
 
   if (is.null(rules_between_covariates)) return(body_table)
 

--- a/tests/testthat/test-add_rules.R
+++ b/tests/testthat/test-add_rules.R
@@ -24,3 +24,15 @@ testthat::expect_equal(
   ),
   vect)
 )
+
+
+testthat::test_that("ncols_models ignored in latex tables", {
+  testthat::expect_equal(
+    add_rules(body_table = vect,
+              rules_between_covariates = NULL,
+              type = "latex", ncols_models = 2L),
+    add_rules(body_table = vect,
+              rules_between_covariates = NULL,
+              type = "latex", ncols_models = 10L),
+  )
+})

--- a/tests/testthat/test-add_rules.R
+++ b/tests/testthat/test-add_rules.R
@@ -1,0 +1,26 @@
+testthat::context('add rules')
+
+vect <- paste0(rep(c("row_coeff", "row_sd", "row_empty"), 10), unlist(lapply(1:10,rep,3)))
+
+
+testthat::expect_equal(
+  add_rules(body_table = vect,
+            rules_between_covariates = NULL,
+            type = "latex", ncols_models = 1L),
+  vect
+)
+
+
+testthat::expect_equal(
+  add_rules(body_table = vect,
+            rules_between_covariates = c(1,2,5),
+            type = "latex", ncols_models = 1L),
+  paste0(c(rep("",3),
+           c(" \\hline \\\\[-1.8ex] ", rep("",2)),
+           c(" \\hline \\\\[-1.8ex] ", rep("",2)),
+           rep("",3*2),
+           c(" \\hline \\\\[-1.8ex] ", rep("",2)),
+           rep("",3*3)
+  ),
+  vect)
+)

--- a/tests/testthat/test-add_rules.R
+++ b/tests/testthat/test-add_rules.R
@@ -29,10 +29,44 @@ testthat::expect_equal(
 testthat::test_that("ncols_models ignored in latex tables", {
   testthat::expect_equal(
     add_rules(body_table = vect,
-              rules_between_covariates = NULL,
+              rules_between_covariates = c(1,2,5),
               type = "latex", ncols_models = 2L),
     add_rules(body_table = vect,
-              rules_between_covariates = NULL,
+              rules_between_covariates = c(1,2,5),
               type = "latex", ncols_models = 10L),
+  )
+})
+
+
+add_rules(body_table = vect,
+          rules_between_covariates = c(1,2,5),
+          type = "html", ncols_models = 2L)
+
+testthat::test_that("ncols_models plugged-in in html tables", {
+  testthat::expect_equal(
+    add_rules(body_table = vect,
+              rules_between_covariates = c(1,2,5),
+              type = "html", ncols_models = 1L),
+    paste0(c(rep("",3),
+             c("<tr><td colspan=\"2\"style=\"border-bottom: 1px solid black\"></td></tr>", rep("",2)),
+             c("<tr><td colspan=\"2\"style=\"border-bottom: 1px solid black\"></td></tr>", rep("",2)),
+             rep("",3*2),
+             c("<tr><td colspan=\"2\"style=\"border-bottom: 1px solid black\"></td></tr>", rep("",2)),
+             rep("",3*3)
+    ),
+    vect)
+  )
+  testthat::expect_equal(
+    add_rules(body_table = vect,
+              rules_between_covariates = c(1,2,5),
+              type = "html", ncols_models = 12L),
+    paste0(c(rep("",3),
+             c("<tr><td colspan=\"13\"style=\"border-bottom: 1px solid black\"></td></tr>", rep("",2)),
+             c("<tr><td colspan=\"13\"style=\"border-bottom: 1px solid black\"></td></tr>", rep("",2)),
+             rep("",3*2),
+             c("<tr><td colspan=\"13\"style=\"border-bottom: 1px solid black\"></td></tr>", rep("",2)),
+             rep("",3*3)
+    ),
+    vect)
   )
 })


### PR DESCRIPTION
Adds forgotten argument `ncols_models` for HTML tables

Close #65 